### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   code-style:
     uses: ./.github/workflows/code-style.yml


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/watcher/security/code-scanning/5](https://github.com/LiquidCats/watcher/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing the repository's contents.
- `packages: write` for interacting with the GitHub Container Registry.
- `id-token: write` for authentication purposes if required by the Docker login action.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within individual jobs if specific permissions are required for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
