### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/watcher/security/code-scanning/1](https://github.com/LiquidCats/watcher/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to repository contents, we will set `contents: read` as the permission. This ensures that the workflow has the minimal access required to perform its tasks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, we will add it at the root level for simplicity and consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
