### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Go Tests
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/watcher/security/code-scanning/2](https://github.com/LiquidCats/watcher/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required for the workflow. Since the workflow only involves checking out code and running tests, the `contents: read` permission is sufficient. This change ensures that the `GITHUB_TOKEN` has limited access, reducing the risk of unintended repository modifications.

The `permissions` block should be added immediately after the `name` field at the top of the file. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
